### PR TITLE
Fix product pack pre-selection from URL

### DIFF
--- a/produit.html
+++ b/produit.html
@@ -55,6 +55,15 @@
       elite: { title: 'Pack Elite', price: 39.99 }
     };
 
+    // Pre-select pack based on URL parameter, if present
+    document.addEventListener('DOMContentLoaded', () => {
+      const params = new URLSearchParams(window.location.search);
+      const pack = params.get('pack');
+      if (pack && packDetails[pack]) {
+        document.getElementById('pack').value = pack;
+      }
+    });
+
     document.getElementById('order-form').addEventListener('submit', function(e) {
       e.preventDefault();
       const pack = document.getElementById('pack').value;


### PR DESCRIPTION
## Summary
- preselect the pack on produit.html based on the `pack` URL parameter

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685e99dba1f8832aa955051b9761ddcb